### PR TITLE
Add much more logging to attestation workload

### DIFF
--- a/.github/workflows/workload-attestation.yml
+++ b/.github/workflows/workload-attestation.yml
@@ -140,9 +140,18 @@ jobs:
           fi
 
           echo "Attempting to parse token to extract UVM compliance"
-
+          
+          echo "Splitting token into header/payload/signature by . delimiter..."
           IFS='.' read -r header payload signature <<< "$token"
+          echo "Successfully split token:"
+          echo "header=$header"
+          echo "payload=$payload"
+          echo "signature=$signature"
+          
+          echo "Base64 decoding payload..."
           payload=$(echo "$payload" | tr '_-' '/+' | base64 -d 2>/dev/null)
+          echo "Base64 decoding payload done:"
+          echo "payload=$payload"
           azure_compliance_status=$(echo "$payload" | jq -r '."x-ms-compliance-status"')
           if [ "$azure_compliance_status" != "azure-compliant-uvm" ]; then
             echo "UVM isn't Azure Compliant"


### PR DESCRIPTION
Attestation workload is very flaky, specifically at the stage of fetching the MAA token and checking UVM compliance.

We currently successfully get a token but it's censored in GHA, so it's hard to understand where the token parsing fails. 

Adding extra logging to give more info for inspection