### PR TITLE
Wait 60 seconds before printing container states

### DIFF
--- a/.github/workflows/workload-attestation.yml
+++ b/.github/workflows/workload-attestation.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
-          sleep 20 # Ensure all states are up to date
+          sleep 60 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-attestation.yml
+++ b/.github/workflows/workload-attestation.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
+          sleep 20 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-long-lived.yml
+++ b/.github/workflows/workload-long-lived.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
+          sleep 20 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-long-lived.yml
+++ b/.github/workflows/workload-long-lived.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
-          sleep 20 # Ensure all states are up to date
+          sleep 60 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-managed-identity.yml
+++ b/.github/workflows/workload-managed-identity.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
+          sleep 20 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-managed-identity.yml
+++ b/.github/workflows/workload-managed-identity.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
-          sleep 20 # Ensure all states are up to date
+          sleep 60 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-many-layers.yml
+++ b/.github/workflows/workload-many-layers.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
+          sleep 20 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-many-layers.yml
+++ b/.github/workflows/workload-many-layers.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
-          sleep 20 # Ensure all states are up to date
+          sleep 60 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-minimal.yml
+++ b/.github/workflows/workload-minimal.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
+          sleep 20 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-minimal.yml
+++ b/.github/workflows/workload-minimal.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
-          sleep 20 # Ensure all states are up to date
+          sleep 60 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-non-confidential.yml
+++ b/.github/workflows/workload-non-confidential.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
+          sleep 20 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-non-confidential.yml
+++ b/.github/workflows/workload-non-confidential.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
-          sleep 20 # Ensure all states are up to date
+          sleep 60 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-server.yml
+++ b/.github/workflows/workload-server.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
+          sleep 20 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \

--- a/.github/workflows/workload-server.yml
+++ b/.github/workflows/workload-server.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Get Container States
         if: always()
         run: |
-          sleep 20 # Ensure all states are up to date
+          sleep 60 # Ensure all states are up to date
           az container show \
             --resource-group $RESOURCE_GROUP \
             --name $DEPLOYMENT_NAME \


### PR DESCRIPTION
This is because we there was a failing run
https://github.com/microsoft/confidential-aci-dashboard/actions/runs/10303747006

Which reported no bad states, but viewing the resource well after the run finished, there was a "Killing" state, I suspect because it hadn't propagated in time for container states to see it

Fix is to wait 60 seconds before getting container states