### PR TITLE
Add 16cpu-16gb and 32cpu-32gb for westus

### DIFF
--- a/.github/workflows/high-spec-centraluseuap.yml
+++ b/.github/workflows/high-spec-centraluseuap.yml
@@ -30,3 +30,21 @@ jobs:
       location: centraluseuap
       cpu: 4
       memory_in_gb: 16
+  
+  minimal-16cpu-16gb:
+    secrets: inherit
+    uses: ./.github/workflows/workload-minimal.yml
+    with:
+      id: 16cpu-16gb
+      location: centraluseuap
+      cpu: 16
+      memory_in_gb: 16
+
+  minimal-32cpu-32gb:
+    secrets: inherit
+    uses: ./.github/workflows/workload-minimal.yml
+    with:
+      id: 32cpu-32gb
+      location: centraluseuap
+      cpu: 32
+      memory_in_gb: 32

--- a/.github/workflows/high-spec-westus.yml
+++ b/.github/workflows/high-spec-westus.yml
@@ -30,3 +30,21 @@ jobs:
       location: westus
       cpu: 4
       memory_in_gb: 16
+
+  minimal-16cpu-16gb:
+    secrets: inherit
+    uses: ./.github/workflows/workload-minimal.yml
+    with:
+      id: 16cpu-16gb
+      location: westus
+      cpu: 16
+      memory_in_gb: 16
+
+  minimal-32cpu-32gb:
+    secrets: inherit
+    uses: ./.github/workflows/workload-minimal.yml
+    with:
+      id: 32cpu-32gb
+      location: westus
+      cpu: 32
+      memory_in_gb: 32


### PR DESCRIPTION
A new fix for 6.1 is applied to westus. It's required to have more than 4 cores to use 6.1 kernel. So adding 16cpu-16gb and 32cpu-32gb to "minimal" CI (these config are already used for other regions like centralindia).