### PR TITLE
Update c-aci-testing version

### DIFF
--- a/scripts/install-c-aci-testing.sh
+++ b/scripts/install-c-aci-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version="1.0.4"
+version="1.0.5"
 gh release download $version -R microsoft/confidential-aci-testing
 pip install c_aci_testing*.tar.gz
 rm c_aci_testing*.tar.gz


### PR DESCRIPTION
This contains the fix which makes `policy_type` settable by environment variable, which this repo assumed was present when it wasn't