### PR TITLE
Don't fail region workflows if heavy-io fails

### DIFF
--- a/.github/workflows/workload-heavy-io.yml
+++ b/.github/workflows/workload-heavy-io.yml
@@ -89,6 +89,7 @@ env:
 jobs:
   heavy-io:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
 
       - name: Checkout

--- a/.github/workflows/workload-heavy-io.yml
+++ b/.github/workflows/workload-heavy-io.yml
@@ -89,7 +89,7 @@ env:
 jobs:
   heavy-io:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: true # This only works because historical results tracks per job and failing jobs are still red
     steps:
 
       - name: Checkout

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,13 @@
     ],
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": true,
-    "python.envFile": "${workspaceFolder}/cacitesting.env"
+    "python.envFile": "${workspaceFolder}/cacitesting.env",
+    "peacock.remoteColor": "#215732",
+    "workbench.colorCustomizations": {
+        "statusBar.background": "#215732",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#2f7c47",
+        "statusBarItem.remoteBackground": "#215732",
+        "statusBarItem.remoteForeground": "#e7e7e7"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,13 +8,5 @@
     ],
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": true,
-    "python.envFile": "${workspaceFolder}/cacitesting.env",
-    "peacock.remoteColor": "#215732",
-    "workbench.colorCustomizations": {
-        "statusBar.background": "#215732",
-        "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#2f7c47",
-        "statusBarItem.remoteBackground": "#215732",
-        "statusBarItem.remoteForeground": "#e7e7e7"
-    }
+    "python.envFile": "${workspaceFolder}/cacitesting.env"
 }


### PR DESCRIPTION
The Heavy IO workload exposes a pretty consistent issue in Confidential ACI, albeit a niche one. Therefore we would like to continue running this workload to have visibility but we don't really want to make the whole dashboard red because of this.

To solve this, we want to run the workload, but not fail the caller 'region' workflow if it fails. This allows us to continue collecting data but without red-ing out our dashboard. We also need to ensure that it doesn't make the workflow entirely green