### PR TITLE
Don't include run id in deployment name

### DIFF
--- a/.github/workflows/workload-attestation-with-wait.yml
+++ b/.github/workflows/workload-attestation-with-wait.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'attestation-with-wait' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'attestation-with-wait' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-attestation.yml
+++ b/.github/workflows/workload-attestation.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'attestation' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'attestation' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-heavy-io.yml
+++ b/.github/workflows/workload-heavy-io.yml
@@ -80,7 +80,7 @@ on:
         default: true
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'heavy-io' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'heavy-io' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-long-lived.yml
+++ b/.github/workflows/workload-long-lived.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'long_lived' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'long_lived' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-managed-identity.yml
+++ b/.github/workflows/workload-managed-identity.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'managed-identity' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'managed-identity' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-many-layers.yml
+++ b/.github/workflows/workload-many-layers.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'many-layers' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'many-layers' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-minimal.yml
+++ b/.github/workflows/workload-minimal.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'minimal' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'minimal' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-non-confidential.yml
+++ b/.github/workflows/workload-non-confidential.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'non-confidential' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'non-confidential' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-server-with-wait.yml
+++ b/.github/workflows/workload-server-with-wait.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'server-with-wait' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'server-with-wait' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io

--- a/.github/workflows/workload-server.yml
+++ b/.github/workflows/workload-server.yml
@@ -61,7 +61,7 @@ on:
         default: generated
 
 env:
-  DEPLOYMENT_NAME: ${{ inputs.id || 'server' }}-${{ inputs.location }}-${{ github.run_id }}-${{ github.run_number }}
+  DEPLOYMENT_NAME: ${{ inputs.id || 'server' }}-${{ inputs.location }}-${{ github.run_number }}
   SUBSCRIPTION: ${{ vars.SUBSCRIPTION }}
   RESOURCE_GROUP: c-aci-dashboard
   REGISTRY: cacidashboard.azurecr.io


### PR DESCRIPTION
The id variable can distinguish different instances so using run_id is unnecessary and it can result in names which are too long for azure